### PR TITLE
Updated examples/http_proxy.rb

### DIFF
--- a/examples/http_proxy.rb
+++ b/examples/http_proxy.rb
@@ -9,6 +9,14 @@ host = "0.0.0.0"
 port = 9889
 puts "listening on #{host}:#{port}..."
 
+##----
+## Note: 
+##    Use of `puts` statements below can cause the loading of corrupt
+##    images if using the proxy to view a page like maps.google.com. 
+##    You will most likely want to remove these statements if you are
+##    using this file as a starting point not only for the reason
+##    stated above but, also for performance reasons. 
+##----
 Proxy.start(:host => host, :port => port) do |conn|
 
   @p = Http::Parser.new
@@ -20,7 +28,7 @@ Proxy.start(:host => host, :port => port) do |conn|
     conn.server session, :host => host, :port => (port || 80)
     conn.relay_to_servers @buffer
 
-    @buffer.clear
+    @buffer = ''
   end
 
   @buffer = ''


### PR DESCRIPTION
The current example was not compatible with Ruby 1.8.7 due to use of
the 'String#clear' method. Also, I added a note to let the user know
that if they would like to use this example as a starting point, they
should remove all the 'puts' statements for performance and also to
avoid the return of corrupt images(as is such in the case of loading
maps.google.com through the proxy).
