### PR TITLE
Moved Proxy and BalancingProxy into the EventMachine namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The above will start em-proxy on port 8080, relay and respond with data from por
 ## Simple port forwarding proxy
 
 ```ruby
-Proxy.start(:host => "0.0.0.0", :port => 80, :debug => true) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 80, :debug => true) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 81
 
   # modify / process request stream

--- a/bin/em-proxy
+++ b/bin/em-proxy
@@ -34,7 +34,7 @@ OptionParser.new do |opts|
 end.parse!
 
 
-Proxy.start(:host => "0.0.0.0", :port => options[:listen] , :debug => options[:verbose]) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => options[:listen] , :debug => options[:verbose]) do |conn|
   if options[:socket]
     conn.server :socket, :socket => options[:socket]
   else

--- a/examples/balancing.rb
+++ b/examples/balancing.rb
@@ -4,165 +4,167 @@ require 'em-proxy'
 require 'ansi/code'
 require 'uri'
 
-# = Balancing Proxy
-#
-# A simple example of a balancing, reverse/forward proxy such as Nginx or HAProxy.
-#
-# Given a list of backends, it's able to distribute requests to backends
-# via different strategies (_random_, _roundrobin_, _balanced_), see <tt>Backend.select</tt>.
-#
-# This example is provided for didactic purposes. Nevertheless, based on some preliminary benchmarks
-# and live tests, it performs well in production usage.
-#
-# You can customize the behaviour of the proxy by changing the <tt>BalancingProxy::Callbacks</tt>
-# callbacks. To give you some ideas:
-#
-# * Store statistics for the proxy load in Redis (eg.: <tt>$redis.incr "proxy>backends>#{backend}>total"</tt>)
-# * Use Redis' _SortedSet_ instead of updating the <tt>Backend.list</tt> hash to allow for polling from external process
-# * Use <b>em-websocket</b>[https://github.com/igrigorik/em-websocket] to build a web frontend for monitoring
-#
-module BalancingProxy
-  extend self
-
-  BACKENDS = [
-    {:url => "http://0.0.0.0:3000"},
-    {:url => "http://0.0.0.0:3001"},
-    {:url => "http://0.0.0.0:3002"}
-  ]
-
-  # Represents a "backend", ie. the endpoint for the proxy.
+module EventMachine
+  # = Balancing Proxy
   #
-  # This could be eg. a WEBrick webserver (see below), so the proxy server works as a _reverse_ proxy.
-  # But it could also be a proxy server, so the proxy server works as a _forward_ proxy.
+  # A simple example of a balancing, reverse/forward proxy such as Nginx or HAProxy.
   #
-  class Backend
-
-    attr_reader   :url, :host, :port
-    attr_accessor :load
-    alias         :to_s :url
-
-    def initialize(options={})
-      raise ArgumentError, "Please provide a :url and :load" unless options[:url]
-      @url   = options[:url]
-      @load  = options[:load] || 0
-      parsed = URI.parse(@url)
-      @host, @port = parsed.host, parsed.port
-    end
-
-    # Select backend: balanced, round-robin or random
-    #
-    def self.select(strategy = :balanced)
-      @strategy = strategy.to_sym
-      case @strategy
-        when :balanced
-          backend = list.sort_by { |b| b.load }.first
-        when :roundrobin
-          @pool   = list.clone if @pool.nil? || @pool.empty?
-          backend = @pool.shift
-        when :random
-          backend = list[ rand(list.size-1) ]
-        else
-          raise ArgumentError, "Unknown strategy: #{@strategy}"
-      end
-
-      Callbacks.on_select.call(backend)
-      yield backend if block_given?
-      backend
-    end
-
-    # List of backends
-    #
-    def self.list
-      @list ||= BACKENDS.map { |backend| new backend }
-    end
-
-    # Return balancing strategy
-    #
-    def self.strategy
-      @strategy
-    end
-
-    # Increment "currently serving requests" counter
-    #
-    def increment_counter
-      self.load += 1
-    end
-
-    # Decrement "currently serving requests" counter
-    #
-    def decrement_counter
-      self.load -= 1
-    end
-
-  end
-
-  # Callbacks for em-proxy events
+  # Given a list of backends, it's able to distribute requests to backends
+  # via different strategies (_random_, _roundrobin_, _balanced_), see <tt>Backend.select</tt>.
   #
-  module Callbacks
-    include ANSI::Code
-    extend  self
-
-    def on_select
-      lambda do |backend|
-        puts black_on_white { 'on_select'.ljust(12) } + " #{backend.inspect}"
-        backend.increment_counter if Backend.strategy == :balanced
-      end
-    end
-
-    def on_connect
-      lambda do |backend|
-        puts black_on_magenta { 'on_connect'.ljust(12) } + ' ' + bold { backend }
-      end
-    end
-
-    def on_data
-      lambda do |data|
-        puts black_on_yellow { 'on_data'.ljust(12) }, data
-        data
-      end
-    end
-
-    def on_response
-      lambda do |backend, resp|
-        puts black_on_green { 'on_response'.ljust(12) } + " from #{backend}", resp
-        resp
-      end
-    end
-
-    def on_finish
-      lambda do |backend|
-        puts black_on_cyan { 'on_finish'.ljust(12) } + " for #{backend}", ''
-        backend.decrement_counter if Backend.strategy == :balanced
-      end
-    end
-
-  end
-
-  # Wrapping the proxy server
+  # This example is provided for didactic purposes. Nevertheless, based on some preliminary benchmarks
+  # and live tests, it performs well in production usage.
   #
-  module Server
-    def run(host='0.0.0.0', port=9999)
+  # You can customize the behaviour of the proxy by changing the <tt>BalancingProxy::Callbacks</tt>
+  # callbacks. To give you some ideas:
+  #
+  # * Store statistics for the proxy load in Redis (eg.: <tt>$redis.incr "proxy>backends>#{backend}>total"</tt>)
+  # * Use Redis' _SortedSet_ instead of updating the <tt>Backend.list</tt> hash to allow for polling from external process
+  # * Use <b>em-websocket</b>[https://github.com/igrigorik/em-websocket] to build a web frontend for monitoring
+  #
+  module BalancingProxy
+    extend self
 
-      puts ANSI::Code.bold { "Launching proxy at #{host}:#{port}...\n" }
+    BACKENDS = [
+      {:url => "http://0.0.0.0:3000"},
+      {:url => "http://0.0.0.0:3001"},
+      {:url => "http://0.0.0.0:3002"}
+    ]
 
-      Proxy.start(:host => host, :port => port, :debug => false) do |conn|
+    # Represents a "backend", ie. the endpoint for the proxy.
+    #
+    # This could be eg. a WEBrick webserver (see below), so the proxy server works as a _reverse_ proxy.
+    # But it could also be a proxy server, so the proxy server works as a _forward_ proxy.
+    #
+    class Backend
 
-        Backend.select do |backend|
+      attr_reader   :url, :host, :port
+      attr_accessor :load
+      alias         :to_s :url
 
-          conn.server backend, :host => backend.host, :port => backend.port
+      def initialize(options={})
+        raise ArgumentError, "Please provide a :url and :load" unless options[:url]
+        @url   = options[:url]
+        @load  = options[:load] || 0
+        parsed = URI.parse(@url)
+        @host, @port = parsed.host, parsed.port
+      end
 
-          conn.on_connect  &Callbacks.on_connect
-          conn.on_data     &Callbacks.on_data
-          conn.on_response &Callbacks.on_response
-          conn.on_finish   &Callbacks.on_finish
+      # Select backend: balanced, round-robin or random
+      #
+      def self.select(strategy = :balanced)
+        @strategy = strategy.to_sym
+        case @strategy
+          when :balanced
+            backend = list.sort_by { |b| b.load }.first
+          when :roundrobin
+            @pool   = list.clone if @pool.nil? || @pool.empty?
+            backend = @pool.shift
+          when :random
+            backend = list[ rand(list.size-1) ]
+          else
+            raise ArgumentError, "Unknown strategy: #{@strategy}"
         end
 
+        Callbacks.on_select.call(backend)
+        yield backend if block_given?
+        backend
       end
+
+      # List of backends
+      #
+      def self.list
+        @list ||= BACKENDS.map { |backend| new backend }
+      end
+
+      # Return balancing strategy
+      #
+      def self.strategy
+        @strategy
+      end
+
+      # Increment "currently serving requests" counter
+      #
+      def increment_counter
+        self.load += 1
+      end
+
+      # Decrement "currently serving requests" counter
+      #
+      def decrement_counter
+        self.load -= 1
+      end
+
     end
 
-    module_function :run
-  end
+    # Callbacks for em-proxy events
+    #
+    module Callbacks
+      include ANSI::Code
+      extend  self
 
+      def on_select
+        lambda do |backend|
+          puts black_on_white { 'on_select'.ljust(12) } + " #{backend.inspect}"
+          backend.increment_counter if Backend.strategy == :balanced
+        end
+      end
+
+      def on_connect
+        lambda do |backend|
+          puts black_on_magenta { 'on_connect'.ljust(12) } + ' ' + bold { backend }
+        end
+      end
+
+      def on_data
+        lambda do |data|
+          puts black_on_yellow { 'on_data'.ljust(12) }, data
+          data
+        end
+      end
+
+      def on_response
+        lambda do |backend, resp|
+          puts black_on_green { 'on_response'.ljust(12) } + " from #{backend}", resp
+          resp
+        end
+      end
+
+      def on_finish
+        lambda do |backend|
+          puts black_on_cyan { 'on_finish'.ljust(12) } + " for #{backend}", ''
+          backend.decrement_counter if Backend.strategy == :balanced
+        end
+      end
+
+    end
+
+    # Wrapping the proxy server
+    #
+    module Server
+      def run(host='0.0.0.0', port=9999)
+
+        puts ANSI::Code.bold { "Launching proxy at #{host}:#{port}...\n" }
+
+        EventMachine::Proxy.start(:host => host, :port => port, :debug => false) do |conn|
+
+          Backend.select do |backend|
+
+            conn.server backend, :host => backend.host, :port => backend.port
+
+            conn.on_connect  &Callbacks.on_connect
+            conn.on_data     &Callbacks.on_data
+            conn.on_response &Callbacks.on_response
+            conn.on_finish   &Callbacks.on_finish
+          end
+
+        end
+      end
+
+      module_function :run
+    end
+
+  end
 end
 
 if __FILE__ == $0
@@ -192,6 +194,6 @@ if __FILE__ == $0
   puts ANSI::Code::green_on_black { "\n=> Send multiple requests to the proxy by running `ruby balancing-client.rb`\n" }
 
   # Start proxy
-  BalancingProxy::Server.run
+  EventMachine::BalancingProxy::Server.run
 
 end

--- a/examples/beanstalkd_interceptor.rb
+++ b/examples/beanstalkd_interceptor.rb
@@ -1,6 +1,6 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 11300) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 11300) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 11301
 
   # put <pri> <delay> <ttr> <bytes>\r\n
@@ -21,7 +21,7 @@ Proxy.start(:host => "0.0.0.0", :port => 11300) do |conn|
 
     data
   end
- 
+
   conn.on_response do |backend, resp|
     p [:resp, resp]
     resp

--- a/examples/duplex.rb
+++ b/examples/duplex.rb
@@ -1,6 +1,6 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 8000, :debug => true) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8000, :debug => true) do |conn|
   @start = Time.now
   @data = Hash.new("")
 

--- a/examples/http_proxy.rb
+++ b/examples/http_proxy.rb
@@ -10,7 +10,7 @@ host = "0.0.0.0"
 port = 9889
 puts "listening on #{host}:#{port}..."
 
-Proxy.start(:host => host, :port => port) do |conn|
+EventMachine::Proxy.start(:host => host, :port => port) do |conn|
 
   @p = Http::Parser.new
   @p.on_headers_complete = proc do |h|
@@ -19,7 +19,7 @@ Proxy.start(:host => host, :port => port) do |conn|
 
     host, port = h['Host'].split(':')
     conn.server session, :host => host, :port => (port || 80) #, :bind_host => conn.sock[0] - # for bind ip
-                         
+
     conn.relay_to_servers @buffer
 
     @buffer.clear

--- a/examples/line_interceptor.rb
+++ b/examples/line_interceptor.rb
@@ -1,16 +1,16 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 81
 
   conn.on_data do |data|
     data
   end
- 
+
   conn.on_response do |backend, resp|
     # substitute all mentions of hello to 'good bye', aka intercepting proxy
     resp.gsub(/hello/, 'good bye')
-  end  
+  end
 end
 
 #

--- a/examples/port_forward.rb
+++ b/examples/port_forward.rb
@@ -1,6 +1,6 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 80, :debug => true) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 80, :debug => true) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 81
 
   # modify / process request stream
@@ -8,11 +8,11 @@ Proxy.start(:host => "0.0.0.0", :port => 80, :debug => true) do |conn|
     p [:on_data, data]
     data
   end
- 
+
   # modify / process response stream
   conn.on_response do |backend, resp|
     p [:on_response, backend, resp]
     # resp = "HTTP/1.1 200 OK\r\nConnection: close\r\nDate: Thu, 30 Apr 2009 03:53:28 GMT\r\nContent-Type: text/plain\r\n\r\nHar!"
     resp
-  end  
+  end
 end

--- a/examples/relay_port_forward.rb
+++ b/examples/relay_port_forward.rb
@@ -1,7 +1,7 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 80, :debug => false) do |conn|
-  # Specifying :relay_server or :relay_client is useful if only requests or responses 
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 80, :debug => false) do |conn|
+  # Specifying :relay_server or :relay_client is useful if only requests or responses
   # need to be processed. The proxy throughput will roughly double.
   conn.server :srv, :host => "127.0.0.1", :port => 81, :relay_client => true, :relay_server => true
 
@@ -15,12 +15,12 @@ Proxy.start(:host => "0.0.0.0", :port => 80, :debug => false) do |conn|
     p [:on_data, data]
     data
   end
- 
+
   # modify / process response stream
   # on_response will not be called when :relay_client => true is passed as server option
   conn.on_response do |backend, resp|
     p [:on_response, backend, resp]
     # resp = "HTTP/1.1 200 OK\r\nConnection: close\r\nDate: Thu, 30 Apr 2009 03:53:28 GMT\r\nContent-Type: text/plain\r\n\r\nHar!"
     resp
-  end  
+  end
 end

--- a/examples/schemaless-mysql/mysql_interceptor.rb
+++ b/examples/schemaless-mysql/mysql_interceptor.rb
@@ -3,7 +3,7 @@ require "em-mysql"
 require "stringio"
 require "fiber"
 
-Proxy.start(:host => "0.0.0.0", :port => 3307) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 3307) do |conn|
   conn.server :mysql, :host => "127.0.0.1", :port => 3306, :relay_server => true
 
   QUERY_CMD = 3
@@ -65,8 +65,8 @@ Proxy.start(:host => "0.0.0.0", :port => 3307) do |conn|
           # keys and values at will. :-)
           #
           # P.S. There is probably cleaner syntax for this, but hey...
-            
-            
+
+
           if insert = sql.match(/\((.*?)\).*?\((.*?)\)/)
             data = {}
             table = query[2]

--- a/examples/selective_forward.rb
+++ b/examples/selective_forward.rb
@@ -1,6 +1,6 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
   @start = Time.now
   @data = Hash.new("")
 
@@ -11,7 +11,7 @@ Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
     # rewrite User-Agent
     [data.gsub(/User-Agent: .*?\r\n/, 'User-Agent: em-proxy/0.1\r\n'), [:prod]]
   end
- 
+
   conn.on_response do |server, resp|
     # only render response from production
     @data[server] += resp
@@ -21,7 +21,7 @@ Proxy.start(:host => "0.0.0.0", :port => 80) do |conn|
   conn.on_finish do |name|
     p [:on_finish, name, Time.now - @start]
     unbind if name == :prod # terminate connection once prod is done
-   
+
     p @data if name == :done
   end
 end

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -1,6 +1,6 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 8080, :debug => true) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080, :debug => true) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 8081
 
   # modify / process request stream

--- a/examples/smtp_spam_filter.rb
+++ b/examples/smtp_spam_filter.rb
@@ -3,7 +3,7 @@ require 'em-http'
 require 'yaml'
 require 'net/http'
 
-Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 2525
 
   RCPT_CMD = /RCPT TO:<(.*)?>\r\n/        # RCPT TO:<name@address.com>\r\n
@@ -43,7 +43,7 @@ Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
 
     data
   end
- 
+
   conn.on_response do |server, resp|
     p [:resp, resp]
 

--- a/examples/smtp_whitelist.rb
+++ b/examples/smtp_whitelist.rb
@@ -1,13 +1,13 @@
 require 'lib/em-proxy'
 
-Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
+EventMachine::Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
   conn.server :srv, :host => "127.0.0.1", :port => 2525
 
   # RCPT TO:<name@address.com>\r\n
   RCPT_CMD = /RCPT TO:<(.*)?>\r\n/
 
   conn.on_data do |data|
-    
+
     if rcpt = data.match(RCPT_CMD)
       if rcpt[1] != "ilya@igvita.com"
        conn.send_data "550 No such user here\n"
@@ -17,7 +17,7 @@ Proxy.start(:host => "0.0.0.0", :port => 2524) do |conn|
 
     data
   end
- 
+
   conn.on_response do |backend, resp|
     resp
   end

--- a/lib/em-proxy/proxy.rb
+++ b/lib/em-proxy/proxy.rb
@@ -1,21 +1,23 @@
-class Proxy
+module EventMachine
+  class Proxy
 
-  def self.start(options, &blk)
-    EM.epoll
-    EM.run do
+    def self.start(options, &blk)
+      EM.epoll
+      EM.run do
 
-      trap("TERM") { stop }
-      trap("INT")  { stop }
+        trap("TERM") { stop }
+        trap("INT")  { stop }
 
-      EventMachine::start_server(options[:host], options[:port],
-                                 EventMachine::ProxyServer::Connection, options) do |c|
-        c.instance_eval(&blk)
+        EventMachine::start_server(options[:host], options[:port],
+                                   EventMachine::ProxyServer::Connection, options) do |c|
+          c.instance_eval(&blk)
+        end
       end
     end
-  end
 
-  def self.stop
-    puts "Terminating ProxyServer"
-    EventMachine.stop
+    def self.stop
+      puts "Terminating ProxyServer"
+      EventMachine.stop
+    end
   end
 end

--- a/spec/balancing_spec.rb
+++ b/spec/balancing_spec.rb
@@ -1,10 +1,10 @@
 require 'helper'
 require File.join(File.dirname(__FILE__), '../', 'examples/balancing')
 
-describe BalancingProxy do
+describe EventMachine::BalancingProxy do
 
   before(:each) do
-    class BalancingProxy::Backend
+    class EventMachine::BalancingProxy::Backend
       @list = nil; @pool = nil
     end
   end
@@ -22,7 +22,7 @@ describe BalancingProxy do
   context "generally" do
 
     it "should raise error for unknown strategy" do
-      lambda { BalancingProxy::Backend.select(:asdf)}.should raise_error(ArgumentError)
+      lambda { EventMachine::BalancingProxy::Backend.select(:asdf)}.should raise_error(ArgumentError)
     end
 
   end
@@ -30,7 +30,7 @@ describe BalancingProxy do
   context "when using the 'random' strategy" do
 
     it "should select random backend" do
-      class BalancingProxy::Backend
+      class EventMachine::BalancingProxy::Backend
         def self.list
           @list ||= [
             {:url => "http://127.0.0.1:3000"},
@@ -41,14 +41,14 @@ describe BalancingProxy do
       end
 
       srand(0)
-      BalancingProxy::Backend.select(:random).host.should == '127.0.0.1'
+      EventMachine::BalancingProxy::Backend.select(:random).host.should == '127.0.0.1'
     end
 
   end
 
   context "when using the 'roundrobin' strategy" do
     it "should select backends in rotating order" do
-      class BalancingProxy::Backend
+      class EventMachine::BalancingProxy::Backend
         def self.list
           @list ||= [
             {:url => "http://127.0.0.1:3000"},
@@ -58,17 +58,17 @@ describe BalancingProxy do
         end
       end
 
-      BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.1'
-      BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.2'
-      BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.3'
-      BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.1'
+      EventMachine::BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.1'
+      EventMachine::BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.2'
+      EventMachine::BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.3'
+      EventMachine::BalancingProxy::Backend.select(:roundrobin).host.should == '127.0.0.1'
     end
   end
 
   context "when using the 'balanced' strategy" do
 
     it "should select the first backend when all backends have the same load" do
-      class BalancingProxy::Backend
+      class EventMachine::BalancingProxy::Backend
         def self.list
           @list ||= [
             {:url => "http://127.0.0.3:3000", :load => 0},
@@ -78,11 +78,11 @@ describe BalancingProxy do
         end
       end
 
-      BalancingProxy::Backend.select.host.should == '127.0.0.3'
+      EventMachine::BalancingProxy::Backend.select.host.should == '127.0.0.3'
     end
 
     it "should select the least loaded backend" do
-      class BalancingProxy::Backend
+      class EventMachine::BalancingProxy::Backend
         def self.list
           @list ||= [
             {:url => "http://127.0.0.3:3000", :load => 2},
@@ -92,10 +92,10 @@ describe BalancingProxy do
         end
       end
 
-      BalancingProxy::Backend.select.host.should == '127.0.0.1'
-      BalancingProxy::Backend.select.host.should == '127.0.0.1'
-      BalancingProxy::Backend.select.host.should == '127.0.0.2'
-      BalancingProxy::Backend.select.host.should == '127.0.0.3'
+      EventMachine::BalancingProxy::Backend.select.host.should == '127.0.0.1'
+      EventMachine::BalancingProxy::Backend.select.host.should == '127.0.0.1'
+      EventMachine::BalancingProxy::Backend.select.host.should == '127.0.0.2'
+      EventMachine::BalancingProxy::Backend.select.host.should == '127.0.0.3'
     end
 
   end

--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Proxy do
+describe EventMachine::Proxy do
 
   def failed
     EventMachine.stop
@@ -13,7 +13,7 @@ describe Proxy do
         EventMachine::HttpRequest.new('http://127.0.0.1:8080/test').get({:timeout => 1})
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.on_data do |data|
           data.should =~ /GET \/test/
           EventMachine.stop
@@ -29,7 +29,7 @@ describe Proxy do
         EventMachine::HttpRequest.new('http://127.0.0.1:8080/').get({:timeout => 1})
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.server :goog, :host => "google.com", :port => 80
 
         conn.on_connect do |name|
@@ -48,7 +48,7 @@ describe Proxy do
         EventMachine::HttpRequest.new('http://127.0.0.1:8080/').get({:timeout => 1})
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.server :goog, :host => "google.com", :port => 80
         conn.on_data { |data| data }
 
@@ -67,7 +67,7 @@ describe Proxy do
         EventMachine::HttpRequest.new('http://127.0.0.1:8080/test').get({:timeout => 1})
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.server :goog, :host => "google.com", :port => 80
         conn.server :yhoo, :host => "yahoo.com", :port => 80
         conn.on_data { |data| data }
@@ -101,7 +101,7 @@ describe Proxy do
         }
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.server :goog, :host => "google.com", :port => 80
         conn.on_data { |data| data }
         conn.on_response do |backend, data|
@@ -117,7 +117,7 @@ describe Proxy do
         EventMachine::HttpRequest.new('http://127.0.0.1:8080/').get({:timeout => 1})
       end
 
-      Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+      EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
         conn.server :goog, :host => "google.com", :port => 80
         conn.on_data { |data| data }
         conn.on_response { |backend, resp| resp }
@@ -137,7 +137,7 @@ describe Proxy do
           http.callback { EventMachine.stop }
         end
 
-        Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+        EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
           conn.server :goog, :host => "google.com", :port => 80, :relay_client => true
           conn.on_data { |data| raise "Should not be here"; data }
           conn.on_response { |backend, resp| resp }
@@ -155,7 +155,7 @@ describe Proxy do
           http.callback { EventMachine.stop }
         end
 
-        Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+        EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
           conn.server :goog, :host => "google.com", :port => 80, :relay_server => true
           conn.on_data { |data| data }
           conn.on_response { |backend, resp| raise "Should not be here"; }
@@ -183,7 +183,7 @@ describe Proxy do
         end
         host = @host
         port = @port
-        Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+        EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
           conn.server :local, :host => host, :port => port
           conn.on_connect do |name|
             connected = true
@@ -211,7 +211,7 @@ describe Proxy do
           EventMachine::HttpRequest.new('http://127.0.0.1:8080/').get({:timeout => 1})
         end
         socket = @socket
-        Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
+        EventMachine::Proxy.start(:host => "0.0.0.0", :port => 8080) do |conn|
           conn.server :local, :socket => socket
           conn.on_connect do |name|
             connected = true


### PR DESCRIPTION
I just got burned defining a `Proxy` and getting a `Proxy`. So someone has to do this - move `Proxy` and `BalancingProxy` into the `EventMachine` module. 

I can see why you wouldn't want this, it will break everybody who uses the gem in a future release. But I thought I'd put it out there :)