### PR TITLE
Fix: spec hangs, resolves #32

### DIFF
--- a/spec/proxy_spec.rb
+++ b/spec/proxy_spec.rb
@@ -86,6 +86,12 @@ describe Proxy do
 
           EventMachine.stop if seen.size == 2
         end
+
+        conn.on_finish do |name|
+          # keep the connection open if we're still expecting a response
+          seen.count == 2 ? :close : :keep
+        end
+
       end
     end
   end


### PR DESCRIPTION
This fixes #32, thanks for the hint. The connection was being closed prematurely. 
