### PR TITLE
Fix: Ruby 1.8.7 specs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       eventmachine
     eventmachine (1.0.0)
     http_parser.rb (0.5.3)
+    posix-spawn (0.3.6)
     rake (0.9.2.2)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
@@ -36,5 +37,6 @@ DEPENDENCIES
   ansi
   em-http-request
   em-proxy!
+  posix-spawn
   rake
   rspec

--- a/em-proxy.gemspec
+++ b/em-proxy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "em-http-request"
   s.add_development_dependency "ansi"
   s.add_development_dependency "rake"
+  s.add_development_dependency "posix-spawn"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -2,5 +2,6 @@ require 'bundler/setup'
 require 'em-http'
 require 'pp'
 require 'tmpdir'
+require 'posix/spawn'
 
 require 'em-proxy'


### PR DESCRIPTION
Use https://github.com/rtomayko/posix-spawn instead of Ruby 1.9.x `spawn` for backward compatibility with Ruby 1.8.7. The library works perfectly well with that.
