### PR TITLE
Minor issue when connection closes

### DIFF
--- a/lib/em-proxy/connection.rb
+++ b/lib/em-proxy/connection.rb
@@ -102,7 +102,7 @@ module EventMachine
 
         # terminate any unfinished connections
         @servers.values.compact.each do |s|
-          s.close_connection
+          s.close_connection_after_writing
         end
       end
 


### PR DESCRIPTION
I found that when the client on the frontend closes the connection, sometimes one (or more) of the backend servers have not written a reply yet.  Since the proxy closes the connection, those backend servers will get an ECONNRESET.  I didn't really notice this until I started stressing the box(es), then it became fairly common to see this error.  

The simple solution was to just close_connection_after_writing (instead of just close_connection), in unbind.I initially put a (lame) timer to close connection after a fixed time interval, but close_connection_after_writing seems to do the job quite well.  

AFAICT, there is no reason not to close_connection_after_writing on these backend connections.  What do you think?
