### PR TITLE
fix require error in schemaless mysql example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .bundle
 pkg
-
+Gemfile.lock

--- a/examples/schemaless-mysql/mysql_interceptor.rb
+++ b/examples/schemaless-mysql/mysql_interceptor.rb
@@ -1,5 +1,5 @@
-require "lib/em-proxy"
-require "em-mysql"
+require_relative "../../lib/em-proxy"
+require "em-mysqlplus"
 require "stringio"
 require "fiber"
 


### PR DESCRIPTION
running the mysql example script on my local machine w/ ruby 2.0 gave an error of `require` failed.

fixed by using `require_relatvie` which is more compatible w/ ruby version >= 1.9.2.

LMK if the `Gemfile.lock` should be included in the repo or not. I personally find it's useless.