### PR TITLE
expose unbind reason for better debugging of connection errors

### DIFF
--- a/lib/em-proxy/backend.rb
+++ b/lib/em-proxy/backend.rb
@@ -27,8 +27,8 @@ module EventMachine
 
       # Notify upstream plexer that the backend server is done
       # processing the request
-      def unbind
-        debug [@name, :unbind]
+      def unbind(reason = nil)
+        debug [@name, :unbind, reason]
         @plexer.unbind_backend(@name)
       end
 

--- a/lib/em-proxy/connection.rb
+++ b/lib/em-proxy/connection.rb
@@ -97,8 +97,8 @@ module EventMachine
         @on_connect.call(name) if @on_connect
       end
 
-      def unbind
-        debug [:unbind, :connection]
+      def unbind(reason = nil)
+        debug [:unbind, :connection, reason]
 
         # terminate any unfinished connections
         @servers.values.compact.each do |s|


### PR DESCRIPTION
more info can be found in this commit:

https://github.com/eventmachine/eventmachine/commit/9943484309

while debugging https://github.com/code-mancers/invoker, `EventMachine::ProxyServer::Backend` connection was failing with `Errno::ECONNREFUSED`. Since `unbind` doesn't capture error reason, i have added support for it. thanks.