### PR TITLE
added missing shebang in examples/balancing-client.rb

### DIFF
--- a/examples/balancing-client.rb
+++ b/examples/balancing-client.rb
@@ -1,5 +1,7 @@
 # A simple HTTP client, which sends multiple requests to the proxy server
 
+#!/usr/bin/env ruby
+
 require 'net/http'
 
 proxy = Net::HTTP::Proxy('0.0.0.0', '9999')


### PR DESCRIPTION
During [Fedora Package Review process](https://bugzilla.redhat.com/show_bug.cgi?id=1348160), for including em-proxy into Fedora repositories, Fabio Alessandro Locati found out that file `examples/balancing-client.rb` misses shebang